### PR TITLE
Fix seeds and add admin email

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  before_action :authenticate_user
   before_action :set_category, only: %i[ show edit update destroy ]
 
   # GET /categories or /categories.json
@@ -61,5 +62,11 @@ class CategoriesController < ApplicationController
     # Only allow a list of trusted parameters through.
     def category_params
       params.require(:category).permit(:namecategory)
+    end
+
+    def authenticate_user
+      if current_user.nil? || current_user.email != "procuponss@gmail.com"
+        redirect_to root_path
+      end
     end
 end

--- a/app/views/mainpages/index.html.erb
+++ b/app/views/mainpages/index.html.erb
@@ -11,7 +11,7 @@
         <% end %>
         <div class='main_cupons_content'><%= render 'content'%></div>
       </div>
-      <div class='main_cupons_bar_right'><%= render 'category'%></div>
+      <div class='main_cupons_bar_right'><%= (render 'category') if current_user && current_user.email == "procuponss@gmail.com"%></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Description

When the user is logged in with the email "procuponss@gmail.com" then the categories section is rendered and they can access it, while they are not logged in with that email it will not be rendered nor will they be able to access it through the routes.

## Screenshots

![image](https://user-images.githubusercontent.com/116856441/229661164-36522d5d-6007-4a31-8399-5bf8f15d481f.png)

![image](https://user-images.githubusercontent.com/116856441/229661208-62b04150-6dfa-4770-ac91-6831097b4cfe.png)

