### PR TITLE
carousel view only in root_path

### DIFF
--- a/app/views/mainpages/index.html.erb
+++ b/app/views/mainpages/index.html.erb
@@ -7,7 +7,7 @@
         <div class='main_header_up'><%= render 'share/header'%> </div>
         <% if params[:home] %>
           <div class='main_cupons_home'><%= render 'home'%></div>
-        <% elsif params[:search].nil? || params[:search] == '' %>
+        <% elsif (params[:search].nil? || params[:search] == '') && (params[:category_id].nil? || params[:category_id] == '') %>
           <div class='main_cupons_carrusel'><%= render 'carousel' if params[:users].nil? %></div>
         <% end %>
         <div class='main_cupons_content'>


### PR DESCRIPTION
# Description

What did you implemented/Why did you implemented this:

I should add that the carousel can only be viewed from the root page because it appeared in the coupon category view.

## Screenshots
![Screenshot from 2023-04-18 21-22-24](https://user-images.githubusercontent.com/72171554/232958833-fd3b1329-5a7a-4f66-872d-508852e0965e.png)
![Screenshot from 2023-04-18 21-22-58](https://user-images.githubusercontent.com/72171554/232958953-86ed333b-e1b3-43b3-8f6d-08a7299d5d01.png)



