### PR TITLE
Fix problem with the button to close the menu left

### DIFF
--- a/app/assets/stylesheets/pages/_main.scss
+++ b/app/assets/stylesheets/pages/_main.scss
@@ -71,10 +71,18 @@
           z-index: 1;
         }
 
+        &_button {
+          align-items: flex-start;
+          display: flex;
+          flex-direction: row;
+          margin: 1rem 0rem;
+          width:100%;
+        }
+
         .navbar__logo__open {
-          color: white;
+          color: $white;
           height: 1.5rem;
-          margin: 1rem 20rem 1rem 0rem;
+          margin: 0 .5rem;
           transform: rotate(90deg);
           width: 2rem;
         }
@@ -97,7 +105,6 @@
       &__logo {
         border-radius: 20px;
         height: auto;
-        padding: 0rem 0rem 2rem 0rem;
         width: 95%;
 
         &__closed {
@@ -164,15 +171,10 @@
     #main {
       padding: 0 0rem 0 1rem;
       transition: margin-left .5s;
-      margin-left: 20rem;
     }
     
     #mySidenav {
       width: 10rem;
-    }
-    
-    #logo {
-      display: none;
     }
     
     #mainService {
@@ -183,10 +185,6 @@
     
     #mySidenavService {
       width: 0;
-    }
-    
-    #logo {
-      display: block;
     }
   }
 

--- a/app/assets/stylesheets/pages/_showCupons.scss
+++ b/app/assets/stylesheets/pages/_showCupons.scss
@@ -22,6 +22,7 @@
     box-sizing: content-box;
     display: flex;
     flex-direction: column;
+    margin-left: 1rem;
     overflow-y: scroll;
     width: 100%;
     

--- a/app/views/share/_menu.html.erb
+++ b/app/views/share/_menu.html.erb
@@ -2,7 +2,7 @@
   <%=  javascript_include_tag 'navbarService' %>
 
   <div id="mySidenavService" class="navbar__container">
-    <a onclick="closeNav()"><%= image_tag("menuburger.svg", class:'navbar__logo__open')%></a>
+      <a onclick="closeNav()" class="navbar__container_button"><%= image_tag("menuburger.svg", class:'navbar__logo__open')%></a>
     <%= link_to root_path do %>
       <%= image_tag("logo02.png", class:'navbar__logo')%>
     <% end %>


### PR DESCRIPTION

# Description

- The left menu now shows the close button.
- Modified the main.scss file, on the 'container' class inside the 'menu_left' class.

- What?: I've solved the problem with the button to close the menu, that button was hidden.
- Why?: This change was mainly needed for mobile devices, so as not to confuse the user about closing the menu.

## Screenshots

![Captura de pantalla -2023-04-19 15-07-00](https://user-images.githubusercontent.com/50371065/233200367-612da573-75e3-4d90-8d09-680e5b698331.png)

![Captura de pantalla -2023-04-19 15-07-33](https://user-images.githubusercontent.com/50371065/233200406-48743a05-097b-4f5b-b17b-a234933516b7.png)

