### PR TITLE
overlay in edit coupon view fixed

### DIFF
--- a/app/views/cupons/edit.html.erb
+++ b/app/views/cupons/edit.html.erb
@@ -1,3 +1,4 @@
+<div id="overlay"></div>
 <div class='cupons_container'>
   <div class='main_menu_left'><%= render 'share/menu'%></div>
   <div class="cupons_container_content">


### PR DESCRIPTION
# Description

I fix an error regarding the view of the menu navbar. because the overlay doesn't appear and the navbar takes all the screen.

## Screenshots

![Screenshot from 2023-04-19 16-17-15](https://user-images.githubusercontent.com/72171554/233211867-7350cf42-989c-4067-ba1f-654be062d8c1.png)

![Screenshot from 2023-04-19 16-21-46](https://user-images.githubusercontent.com/72171554/233212585-303847cf-cb4c-40f7-aebb-051c959003dc.png)
